### PR TITLE
Modification to examples

### DIFF
--- a/examples/Basic.java
+++ b/examples/Basic.java
@@ -68,6 +68,10 @@ public class Basic
 			/* Show exit status, if available (otherwise "null") */
 
 			System.out.println("ExitCode: " + sess.getExitStatus());
+			
+			/* close buffer Reader */
+			
+			br.close();
 
 			/* Close this session */
 

--- a/examples/BasicWithHTTPProxy.java
+++ b/examples/BasicWithHTTPProxy.java
@@ -79,6 +79,10 @@ public class BasicWithHTTPProxy
 			/* Show exit status, if available (otherwise "null") */
 
 			System.out.println("ExitCode: " + sess.getExitStatus());
+			
+			/* close buffer Reader */
+			
+			br.close();
 
 			/* Close this session */
 

--- a/examples/PublicKeyAuthentication.java
+++ b/examples/PublicKeyAuthentication.java
@@ -58,7 +58,11 @@ public class PublicKeyAuthentication
 					break;
 				System.out.println(line);
 			}
-
+			
+			/* close buffer Reader */
+			
+			br.close();
+			
 			/* Close this session */
 			
 			sess.close();

--- a/examples/StdoutAndStderr.java
+++ b/examples/StdoutAndStderr.java
@@ -67,6 +67,12 @@ public class StdoutAndStderr
 					break;
 				System.out.println(line);
 			}
+
+
+			/* close the buffer reader */
+			
+			stdoutReader.close();
+			stderrReader.close();
 			
 			/* Close this session */
 			

--- a/examples/UsingKnownHosts.java
+++ b/examples/UsingKnownHosts.java
@@ -66,6 +66,10 @@ public class UsingKnownHosts
 				System.out.println(line);
 			}
 
+			/* close the buffer reader */
+			
+			br.close();
+			
 			/* Close this session */
 
 			sess.close();


### PR DESCRIPTION
Without these changes, examples might memory Leak. 
So Closing Buffer Readers that are being used at the end,
